### PR TITLE
tinycompress: Add conditional compilation check for compress param

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -552,8 +552,13 @@ int compress_set_next_track_param(struct compress *compress,
 	if (!is_compress_running(compress))
 		return oops(compress, ENODEV, "device not ready");
 
+	if (codec_options == NULL)
+		return oops(compress, ENODEV, "codec_option NULL");
+
+#ifdef SNDRV_COMPRESS_SET_NEXT_TRACK_PARAM
 	if (ioctl(compress->fd, SNDRV_COMPRESS_SET_NEXT_TRACK_PARAM, codec_options))
 		return oops(compress, errno, "cannot set next track params\n");
+#endif
 	return 0;
 }
 #endif


### PR DESCRIPTION
This is needed for proper compilation on kernel versions where SNDRV_COMPRESS_SET_NEXT_TRACK_PARAM is not defined

CRs-Fixed: 2838117
Change-Id: Ia0b2593b5dc1e0cf751ac11e64d347644b8bee39